### PR TITLE
Fix parse error if a docstring occurs at EOF without a newline

### DIFF
--- a/src/feature.pest
+++ b/src/feature.pest
@@ -103,7 +103,7 @@ step = {
     ~ (
         (datatable | docstring)
         ~ space*
-        ~ nl
+        ~ (nl | eoi)
     )?
 }
 

--- a/src/test.feature
+++ b/src/test.feature
@@ -39,3 +39,9 @@ Scenario Outline: eating
     | start | eat | left |
     |    12 |   5 |    7 |
     |    20 |   5 |   15 |
+
+Scenario: A step with a doc comment and no new line at the end of the doc
+Given a
+"""
+there's no newline following this docstring
+"""


### PR DESCRIPTION
There's currently a bug in the parser in that a feature file that ends in a docstring without a final newline is a parse error. This PR fixes that.