### PR TITLE
Don't require a blank line before Examples section

### DIFF
--- a/src/feature.pest
+++ b/src/feature.pest
@@ -137,7 +137,7 @@ scenario = {
     ~ (tags ~ nl)?
     ~ scenario_kw ~ scenario_name ~ nl
     ~ scenario_steps
-    ~ (nl+ ~ examples)?
+    ~ (nl* ~ examples)?
 }
 
 background_kw = _{


### PR DESCRIPTION
`scenario_steps` already ends in a newline, so `(nl+ ~ examples)` resulted in requiring an extra newline