### PR TITLE
Bug #16: Using tabs as an indentation breaks feature file parsing

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -175,16 +175,16 @@ impl Default for GherkinEnv {
 
 peg::parser! { pub(crate) grammar gherkin_parser(env: &GherkinEnv) for str {
 
-rule _() = quiet!{[' ']*}
-rule __() = quiet!{[' ']+}
+rule _() = quiet!{[' ' | '\t']*}
+rule __() = quiet!{[' ' | '\t']+}
 
 rule nl0() = quiet!{"\r"? "\n"}
 rule nl() = quiet!{nl0() p:position!() comment()* {
     env.increment_nl(p);
 }} 
 rule eof() = quiet!{![_]}
-rule nl_eof() = quiet!{(nl() / [' '])+ / eof()}
-rule comment() = quiet!{[' ']* "#" $((!nl0()[_])*) nl()}
+rule nl_eof() = quiet!{(nl() / [' ' | '\t'])+ / eof()}
+rule comment() = quiet!{[' ' | '\t']* "#" $((!nl0()[_])*) nl()}
 rule not_nl() -> &'input str = n:$((!nl0()[_])+) { n }
 
 rule keyword1(list: &[&'static str]) -> &'static str

--- a/tests/test.feature
+++ b/tests/test.feature
@@ -41,6 +41,13 @@ Scenario Outline: eating
     |    12 |   5 |    7 |
     |    20 |   5 |   15 |
 
+@scenario-with-tab-indentation
+Scenario: A second scenario test
+# Below are TABs don't remove/convert them
+	Given I have not been testing much
+	Then I should probably start doing it
+# Above are TABs don't remove/convert them
+
 Scenario: A step with a doc comment and no new line at the end of the doc
 Given a
 """


### PR DESCRIPTION
Added support for \t as an indentation character