### PR TITLE
[Add][Doc] Links and references to upstream docs

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD004": { "style": "asterisk" }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # gherkin-rust
 
 A pure Rust implementation of the Gherkin (`.feature` file) language for the Cucumber testing framework.
+For a detailed description of Gherkin usage:
+
+1. for Cucumber **developers** please consult:
+   * [the Gherkin readme](https://github.com/cucumber/cucumber/blob/master/gherkin/README.md)
+   * [the Gherkin contributing guide](https://github.com/cucumber/cucumber/blob/master/gherkin/CONTRIBUTING.md)
+1. for Cucumber **users** please consult:
+   * [the Cucumber user documentation](https://cucumber.io/docs/cucumber/).
+   * [the Gherkin user documentation](https://cucumber.io/docs/gherkin/).
 
 If you want to run Cucumber tests in Rust, try [cucumber-rust](https://github.com/bbqsrc/cucumber-rust)!
 
@@ -15,8 +23,8 @@ gherkin-rust = "0.9"
 
 This project is licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 


### PR DESCRIPTION
What:
Incremental progress in aligning documentation with upstream.

Why:
1. Direct new Cucumber-Rust users and developers to the accumulated
  knowledge and experience of the broader Cucumber/Gherkin community.
2. Assure experienced Cucumber users and developers that
  Cucumber-Rust is not a snowflake implementation.

How:
Added markdown links to read-me markdown file.

Signed-off-by: Begley Brothers Inc <begleybrothers@gmail.com>